### PR TITLE
fix: correctly convert timezone offset from Java TimeZone.getRawOffse…

### DIFF
--- a/service/src/main/java/com/github/kr328/clash/service/clash/module/TimeZoneModule.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/clash/module/TimeZoneModule.kt
@@ -14,7 +14,7 @@ class TimeZoneModule(service: Service) : Module<Unit>(service) {
         while (true) {
             val timeZone = TimeZone.getDefault()
 
-            Clash.notifyTimeZoneChanged(timeZone.id, timeZone.rawOffset)
+            Clash.notifyTimeZoneChanged(timeZone.id, timeZone.rawOffset / 1000)
 
             timeZones.receive()
         }


### PR DESCRIPTION
…t() to arg for golang time.FixedZone