### PR TITLE
Use CMake string(TIMESTAMP) for portable compile timestamp

### DIFF
--- a/core/src/main/cpp/CMakeLists.txt
+++ b/core/src/main/cpp/CMakeLists.txt
@@ -28,11 +28,7 @@ string (REGEX REPLACE "[\n\t\r]" "" CURRENT_BRANCH ${CURRENT_BRANCH})
 message(STATUS "git current branch = ${CURRENT_BRANCH}")
 
 # 获取生成时间
-execute_process(
-  COMMAND date +"%y%m%d"
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} 
-  OUTPUT_VARIABLE COMPILE_TIME
-)
+string(TIMESTAMP COMPILE_TIME "%y%m%d")
 string (REGEX REPLACE "[\n\t\r]" "" COMPILE_TIME ${COMPILE_TIME})
 string(REGEX REPLACE "\"" "" COMPILE_TIME ${COMPILE_TIME})
 


### PR DESCRIPTION
The previous usage of the date command is not portable across different platforms. date is not guaranteed to be available and the format varies.

Replace it with CMake's built-in string(TIMESTAMP) command which generates a string with the given timestamp format independent of the platform. This commit changes it to use "%y%m%d" format for a YYMMDD timestamp commonly used for compilation.